### PR TITLE
Bump dependencies to allow usage with rails 5.1

### DIFF
--- a/zapier_rest_hooks.gemspec
+++ b/zapier_rest_hooks.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "~> 4.2.3", "~> 5.0"
+  s.add_dependency "rails", "~> 5.0"
   s.add_dependency("rest-client", "~> 1.8.0", ">= 1.8.0")
 
   s.add_development_dependency "rspec-rails", "~> 3.4"

--- a/zapier_rest_hooks.gemspec
+++ b/zapier_rest_hooks.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "~> 4.2.3", ">= 4.2.3"
+  s.add_dependency "rails", "~> 4.2.3", "~> 5.0"
   s.add_dependency("rest-client", "~> 1.8.0", ">= 1.8.0")
 
   s.add_development_dependency "rspec-rails", "~> 3.4"

--- a/zapier_rest_hooks.gemspec
+++ b/zapier_rest_hooks.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", "~> 5.0"
-  s.add_dependency("rest-client", "~> 1.8.0", ">= 1.8.0")
+  s.add_dependency("rest-client", "~> 2.0.0", ">= 2.0.0")
 
   s.add_development_dependency "rspec-rails", "~> 3.4"
   s.add_development_dependency "sqlite3", "~> 1.3", ">= 1.3.11"


### PR DESCRIPTION
I wasn't entirely sure how to keep compatibility with the current version ranges while also allowing newer versions of the dependencies to be used but I figured it's a good starting spot.