### PR TITLE
Updated rest-client dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     zapier_rest_hooks (0.0.2)
       rails (~> 5.1, >= 5.1.0)
-      rest-client (~> 1.8)
+      rest-client (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -75,10 +75,12 @@ GEM
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
-    mime-types (2.99.3)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -118,10 +120,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.3.1)
-    rest-client (1.8.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)

--- a/app/controllers/zapier_rest_hooks/application_controller.rb
+++ b/app/controllers/zapier_rest_hooks/application_controller.rb
@@ -1,5 +1,4 @@
 module ZapierRestHooks
-  class ApplicationController < ActionController::Base
-    protect_from_forgery with: :exception
+  class ApplicationController < ActionController::API
   end
 end

--- a/zapier_rest_hooks.gemspec
+++ b/zapier_rest_hooks.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", "~> 5.1", ">= 5.1.0"
-  s.add_dependency "rest-client", "~> 1.8"
+  s.add_dependency "rest-client", "~> 2.0"
 
   s.add_development_dependency "rspec-rails", "~> 3.8"
   s.add_development_dependency "sqlite3", "~> 1.3", ">= 1.3.11"


### PR DESCRIPTION
The rest-client 1.8 version depended on an old mime-types gem.